### PR TITLE
Allow user to specify a custom project (tsconfig path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,26 @@ provided for you.
 Then the `tsconfig.json` file will be used as the default project
 for code hints in VSCode, neovim, tests, etc.
 
+### Custom `project`
+
+Configure `tshy.project` if you want tshy to extend from a custom
+tsconfig file. This is often useful when you have multiple
+`tsconfig` files for different tools:
+
+- A default `tsconfig.json` for typechecking and type-aware
+  `typescript-eslint`, specifying `"noEmit": true` and
+  `"include": ["**/*.ts"]`
+- A `tsconfig.build.json` for compilation, with `"noEmit":
+  false`. Note that the [caveats](#tsconfigs) above still apply.
+
+```json
+{
+  "tshy": {
+    "project": "./tsconfig.build.json"
+  }
+}
+```
+
 ## `src/package.json`
 
 As of TypeScript 5.2, the only way to emit JavaScript to ESM or

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import validDialects from './valid-dialects.js'
 import validExports from './valid-exports.js'
 import validExtraDialects from './valid-extra-dialects.js'
 import validImports from './valid-imports.js'
+import validProject from './valid-project.js'
 
 const validBoolean = (e: Record<string, any>, name: string) => {
   const v = e[name]
@@ -23,6 +24,7 @@ const validConfig = (e: any): e is TshyConfig =>
   typeof e === 'object' &&
   (e.exports === undefined || validExports(e.exports)) &&
   (e.dialects === undefined || validDialects(e.dialects)) &&
+  (e.project === undefined || validProject(e.project)) &&
   validExtraDialects(e) &&
   validBoolean(e, 'selfLink') &&
   validBoolean(e, 'main')

--- a/src/read-typescript-config.ts
+++ b/src/read-typescript-config.ts
@@ -3,12 +3,13 @@
 // are jsonc.
 import { resolve } from 'path'
 import ts from 'typescript'
+import config from './config.js'
 const { readFile } = ts.sys
 
 let parsedTsConfig: ts.ParsedCommandLine | undefined = undefined
 export default () => {
   if (parsedTsConfig) return parsedTsConfig
-  const configPath = resolve('tsconfig.json')
+  const configPath = config.project ?? resolve('tsconfig.json')
   const readResult = ts.readConfigFile(configPath, readFile)
   return (parsedTsConfig = ts.parseJsonConfigFileContent(
     readResult.config,

--- a/src/tsconfig.ts
+++ b/src/tsconfig.ts
@@ -41,7 +41,10 @@ const recommended: Record<string, any> = {
 }
 
 const build: Record<string, any> = {
-  extends: '../tsconfig.json',
+  extends:
+    config.project === undefined
+      ? '../tsconfig.json'
+      : join('..', config.project),
   compilerOptions: {
     rootDir: '../src',
     target: 'es2022',
@@ -96,7 +99,7 @@ const writeConfig = (name: string, data: Record<string, any>) =>
   )
 
 console.debug(chalk.cyan.dim('writing tsconfig files...'))
-if (!existsSync('tsconfig.json')) {
+if (config.project === undefined && !existsSync('tsconfig.json')) {
   console.debug('using recommended tsconfig.json')
   writeConfig('../tsconfig', recommended)
 } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type TshyConfig = {
   main?: boolean
   commonjsDialects?: string[]
   esmDialects?: string[]
+  project?: string
 }
 
 export type Dialect = 'commonjs' | 'esm'

--- a/src/valid-project.ts
+++ b/src/valid-project.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'path'
+import { readFileSync } from 'node:fs'
+import fail from './fail.js'
+import { TshyConfig } from './types.js'
+
+export default (p: any): p is TshyConfig['project'] => {
+  if (typeof p === 'string') {
+    try {
+      readFileSync(resolve(p), 'utf8')
+      return true
+    } catch (_) {}
+  }
+
+  fail(
+    `tshy.project must point to a tsconfig file on disk, ` +
+      `got: ${JSON.stringify(p)}`
+  )
+  return process.exit(1)
+}

--- a/tap-snapshots/test/config.ts.test.cjs
+++ b/tap-snapshots/test/config.ts.test.cjs
@@ -24,3 +24,7 @@ invalid imports module specifier: 0
 exports[`test/config.ts > TAP > {"config":{"main":"blah"},"sources":[],"ok":false} > must match snapshot 1`] = `
 tshy.main must be a boolean value if specified, got: blah
 `
+
+exports[`test/config.ts > TAP > {"config":{"project":"thisFileDoesNotExist.json"},"sources":[],"ok":false} > must match snapshot 1`] = `
+tshy.project must point to a tsconfig file on disk, got: "thisFileDoesNotExist.json"
+`

--- a/tap-snapshots/test/tsconfig.ts.test.cjs
+++ b/tap-snapshots/test/tsconfig.ts.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/tsconfig.ts > TAP > .tshy/build.json 1`] = `
+exports[`test/tsconfig.ts > TAP > with custom project tsconfig name > .tshy/build.json 1`] = `
 Object {
   "compilerOptions": Object {
     "module": "nodenext",
@@ -13,23 +13,11 @@ Object {
     "rootDir": "../src",
     "target": "es2022",
   },
-  "extends": "../tsconfig.json",
+  "extends": "../custom.json",
 }
 `
 
-exports[`test/tsconfig.ts > TAP > .tshy/build.json generate everything 1`] = `
-Object {
-  "compilerOptions": Object {
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "rootDir": "../src",
-    "target": "es2022",
-  },
-  "extends": "../tsconfig.json",
-}
-`
-
-exports[`test/tsconfig.ts > TAP > .tshy/commonjs.json 1`] = `
+exports[`test/tsconfig.ts > TAP > with custom project tsconfig name > .tshy/commonjs.json 1`] = `
 Object {
   "compilerOptions": Object {
     "outDir": "../.tshy-build/commonjs",
@@ -47,25 +35,7 @@ Object {
 }
 `
 
-exports[`test/tsconfig.ts > TAP > .tshy/commonjs.json generate everything 1`] = `
-Object {
-  "compilerOptions": Object {
-    "outDir": "../.tshy-build/commonjs",
-  },
-  "exclude": Array [
-    "../src/**/*.mts",
-    "../src/index-deno.mts",
-  ],
-  "extends": "./build.json",
-  "include": Array [
-    "../src/**/*.ts",
-    "../src/**/*.cts",
-    "../src/**/*.tsx",
-  ],
-}
-`
-
-exports[`test/tsconfig.ts > TAP > .tshy/deno.json 1`] = `
+exports[`test/tsconfig.ts > TAP > with custom project tsconfig name > .tshy/deno.json 1`] = `
 Object {
   "compilerOptions": Object {
     "outDir": "../.tshy-build/deno",
@@ -82,7 +52,7 @@ Object {
 }
 `
 
-exports[`test/tsconfig.ts > TAP > .tshy/esm.json 1`] = `
+exports[`test/tsconfig.ts > TAP > with custom project tsconfig name > .tshy/esm.json 1`] = `
 Object {
   "compilerOptions": Object {
     "outDir": "../.tshy-build/esm",
@@ -100,25 +70,7 @@ Object {
 }
 `
 
-exports[`test/tsconfig.ts > TAP > .tshy/esm.json generate everything 1`] = `
-Object {
-  "compilerOptions": Object {
-    "outDir": "../.tshy-build/esm",
-  },
-  "exclude": Array [
-    ".././src/index-cjs.cts",
-    ".././src/index-deno.mts",
-  ],
-  "extends": "./build.json",
-  "include": Array [
-    "../src/**/*.ts",
-    "../src/**/*.mts",
-    "../src/**/*.tsx",
-  ],
-}
-`
-
-exports[`test/tsconfig.ts > TAP > .tshy/webpack.json 1`] = `
+exports[`test/tsconfig.ts > TAP > with custom project tsconfig name > .tshy/webpack.json 1`] = `
 Object {
   "compilerOptions": Object {
     "outDir": "../.tshy-build/webpack",
@@ -137,7 +89,7 @@ Object {
 }
 `
 
-exports[`test/tsconfig.ts > TAP > tsconfig.json 1`] = `
+exports[`test/tsconfig.ts > TAP > with custom project tsconfig name > custom.json 1`] = `
 Object {
   "compilerOptions": Object {
     "this_data": "is preserved",
@@ -146,7 +98,148 @@ Object {
 }
 `
 
-exports[`test/tsconfig.ts > TAP > tsconfig.json generate everything 1`] = `
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/build.json 1`] = `
+Object {
+  "compilerOptions": Object {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "rootDir": "../src",
+    "target": "es2022",
+  },
+  "extends": "../tsconfig.json",
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/build.json generate everything 1`] = `
+Object {
+  "compilerOptions": Object {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "rootDir": "../src",
+    "target": "es2022",
+  },
+  "extends": "../tsconfig.json",
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/commonjs.json 1`] = `
+Object {
+  "compilerOptions": Object {
+    "outDir": "../.tshy-build/commonjs",
+  },
+  "exclude": Array [
+    "../src/**/*.mts",
+    "../src/index-deno.mts",
+  ],
+  "extends": "./build.json",
+  "include": Array [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx",
+  ],
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/commonjs.json generate everything 1`] = `
+Object {
+  "compilerOptions": Object {
+    "outDir": "../.tshy-build/commonjs",
+  },
+  "exclude": Array [
+    "../src/**/*.mts",
+    "../src/index-deno.mts",
+  ],
+  "extends": "./build.json",
+  "include": Array [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx",
+  ],
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/deno.json 1`] = `
+Object {
+  "compilerOptions": Object {
+    "outDir": "../.tshy-build/deno",
+  },
+  "exclude": Array [
+    ".././src/index-cjs.cts",
+  ],
+  "extends": "./build.json",
+  "include": Array [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx",
+  ],
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/esm.json 1`] = `
+Object {
+  "compilerOptions": Object {
+    "outDir": "../.tshy-build/esm",
+  },
+  "exclude": Array [
+    ".././src/index-cjs.cts",
+    ".././src/index-deno.mts",
+  ],
+  "extends": "./build.json",
+  "include": Array [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx",
+  ],
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/esm.json generate everything 1`] = `
+Object {
+  "compilerOptions": Object {
+    "outDir": "../.tshy-build/esm",
+  },
+  "exclude": Array [
+    ".././src/index-cjs.cts",
+    ".././src/index-deno.mts",
+  ],
+  "extends": "./build.json",
+  "include": Array [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx",
+  ],
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > .tshy/webpack.json 1`] = `
+Object {
+  "compilerOptions": Object {
+    "outDir": "../.tshy-build/webpack",
+  },
+  "exclude": Array [
+    "../src/**/*.mts",
+    "../src/index-cjs.cts",
+    "../src/index-deno.mts",
+  ],
+  "extends": "./build.json",
+  "include": Array [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx",
+  ],
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > tsconfig.json 1`] = `
+Object {
+  "compilerOptions": Object {
+    "this_data": "is preserved",
+    "yolo": "🍑",
+  },
+}
+`
+
+exports[`test/tsconfig.ts > TAP > with tsconfig.json file > tsconfig.json generate everything 1`] = `
 Object {
   "compilerOptions": Object {
     "declaration": true,

--- a/test/config.ts
+++ b/test/config.ts
@@ -60,6 +60,8 @@ const cases: [
 
   //@ts-expect-error
   [{ imports: ['blah'] }, [], false, {}],
+
+  [{ project: 'thisFileDoesNotExist.json' }, [], false, {}],
 ]
 
 t.plan(cases.length)

--- a/test/fixtures/basic-custom-project/.tshy/build.json
+++ b/test/fixtures/basic-custom-project/.tshy/build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.custom.json",
+  "compilerOptions": {
+    "rootDir": "../src",
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/test/fixtures/basic-custom-project/.tshy/commonjs.json
+++ b/test/fixtures/basic-custom-project/.tshy/commonjs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [
+    "../src/**/*.mts"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/commonjs"
+  }
+}

--- a/test/fixtures/basic-custom-project/.tshy/esm.json
+++ b/test/fixtures/basic-custom-project/.tshy/esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/esm"
+  }
+}

--- a/test/fixtures/basic-custom-project/package.json
+++ b/test/fixtures/basic-custom-project/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@my/package",
+  "type": "module",
+  "tshy": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    },
+    "project": "./tsconfig.custom.json"
+  }
+}

--- a/test/fixtures/basic-custom-project/src/index.ts
+++ b/test/fixtures/basic-custom-project/src/index.ts
@@ -1,0 +1,3 @@
+export const test = () => {
+  console.log('hello')
+}

--- a/test/fixtures/basic-custom-project/tsconfig.custom.json
+++ b/test/fixtures/basic-custom-project/tsconfig.custom.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
+    "jsx": "react",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022"
+  }
+}

--- a/test/unbuilt-imports.ts
+++ b/test/unbuilt-imports.ts
@@ -16,6 +16,7 @@ t.test('imports linking', async t => {
     'imports-with-star',
     'basic',
     'basic-imports-only-deps',
+    'basic-custom-project',
   ]) {
     t.test(i, async t => {
       // keep the pjs unmodified


### PR DESCRIPTION
Related: #38

This PR adds a new `project` config for tshy to extend from. With this new option, you can have separate tsconfigs for typechecking (linting) and compilation, where tshy will only be using the compilation config. Let me know how you feel about this approach!

### Why?

It's common to have multiple tsconfig files co-exist in a project, where:
- The default `tsconfig.json` contains `"noEmit": true` and `"include": ["**/*.ts"]`. This is used by typechecking and type-aware `typescript-eslint`; VSCode also picks up this file by default.
- A separate `tsconfig.build.json` for compilation, invoked via `tsc -p tsconfig.build.json` (or TypeScript project references in a monorepo).

Here's a real-world monorepo example:
- Leaf [`tsconfig.json`](https://github.com/keyz/shared/blob/f9911943cd6631c4ab92595a4afdf9ed7a5b760a/packages/stdlib/tsconfig.json#L4) (default), [`tsconfig.build.json`](https://github.com/keyz/shared/blob/f9911943cd6631c4ab92595a4afdf9ed7a5b760a/packages/stdlib/tsconfig.build.json#L4), and type-aware [eslint config](https://github.com/keyz/shared/blob/f9911943cd6631c4ab92595a4afdf9ed7a5b760a/packages/stdlib/.eslintrc.js#L10-L13)
- Root [`tsconfig.build.json`](https://github.com/keyz/shared/blob/f9911943cd6631c4ab92595a4afdf9ed7a5b760a/tsconfig.build.json), [`tsconfig.typecheck.json`](https://github.com/keyz/shared/blob/f9911943cd6631c4ab92595a4afdf9ed7a5b760a/tsconfig.typecheck.json), and the [script](https://github.com/keyz/shared/blob/f9911943cd6631c4ab92595a4afdf9ed7a5b760a/package.json#L5) to invoke compilation
