### PR TITLE
Take "target" from base tsconfig when present

### DIFF
--- a/.tshy/build.json
+++ b/.tshy/build.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "../src",
-    "target": "es2022",
     "module": "nodenext",
     "moduleResolution": "nodenext"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.13
+
+- Take `target` from `tsconfig.json` if present, rather than
+  hard-coding in the `build.json` config.
+
 # 1.12
 
 - Respect `package.json` type field if set to `"commonjs"`

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ following caveats:
   - `outDir` - will be overridden based on build, best omitted
   - `rootDir` - will be set to `./src` in the build, can only
     cause annoying errors otherwise.
-  - `target` - will be set to `es2022`
+  - `target` - will be set to `es2022` if not specified
   - `module` - will be set to `NodeNext`
   - `moduleResolution` - will be set to `NodeNext`
 

--- a/src/tsconfig.ts
+++ b/src/tsconfig.ts
@@ -14,6 +14,7 @@ import * as console from './console.js'
 import config from './config.js'
 import polyfills from './polyfills.js'
 import preventVerbatimModuleSyntax from './prevent-verbatim-module-syntax.js'
+import readTypescriptConfig from './read-typescript-config.js'
 
 const {
   dialects = ['esm', 'commonjs'],
@@ -43,18 +44,21 @@ const recommended: Record<string, any> = {
   },
 }
 
-const build: Record<string, any> = {
+const build = (): Record<string, any> => ({
   extends:
     config.project === undefined
       ? '../tsconfig.json'
       : join('..', config.project),
   compilerOptions: {
+    target:
+      readTypescriptConfig().options.target === undefined
+        ? 'es2022'
+        : undefined,
     rootDir: '../src',
-    target: 'es2022',
     module: 'nodenext',
     moduleResolution: 'nodenext',
   },
-}
+})
 
 const commonjs = (dialect: string): Record<string, any> => {
   const exclude = [...relativeExclude, '../src/**/*.mts']
@@ -112,7 +116,7 @@ if (config.project === undefined && !existsSync('tsconfig.json')) {
 for (const f of readdirSync('.tshy')) {
   unlinkSync(resolve('.tshy', f))
 }
-writeConfig('build', build)
+writeConfig('build', build())
 if (dialects.includes('commonjs')) {
   writeConfig('commonjs', commonjs('cjs'))
   for (const d of commonjsDialects) {

--- a/tap-snapshots/test/tsconfig.ts.test.cjs
+++ b/tap-snapshots/test/tsconfig.ts.test.cjs
@@ -116,7 +116,6 @@ Object {
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "rootDir": "../src",
-    "target": "es2022",
   },
   "extends": "../tsconfig.json",
 }

--- a/test/fixtures/basic-custom-project/.tshy/build.json
+++ b/test/fixtures/basic-custom-project/.tshy/build.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.custom.json",
   "compilerOptions": {
     "rootDir": "../src",
-    "target": "es2022",
     "module": "nodenext",
     "moduleResolution": "nodenext"
   }

--- a/test/fixtures/basic-imports-only-deps/.tshy/build.json
+++ b/test/fixtures/basic-imports-only-deps/.tshy/build.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "../src",
-    "target": "es2022",
     "module": "nodenext",
     "moduleResolution": "nodenext"
   }

--- a/test/fixtures/basic/.tshy/build.json
+++ b/test/fixtures/basic/.tshy/build.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "../src",
-    "target": "es2022",
     "module": "nodenext",
     "moduleResolution": "nodenext"
   }

--- a/test/fixtures/imports-with-star/.tshy/build.json
+++ b/test/fixtures/imports-with-star/.tshy/build.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "../src",
-    "target": "es2022",
     "module": "nodenext",
     "moduleResolution": "nodenext"
   }

--- a/test/fixtures/imports/.tshy/build.json
+++ b/test/fixtures/imports/.tshy/build.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "../src",
-    "target": "es2022",
     "module": "nodenext",
     "moduleResolution": "nodenext"
   }


### PR DESCRIPTION
Following up on #54 with the suggested fix. It works for us when we try to build in our Azure SDK repo, but unsure if it would cause issues for folks who have their own tsconfig.json with target unset and are relying on tshy to set the target?