### PR TITLE
Fix require function name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Consider this contrived example:
 // import the class from ESM
 import { SomeClass } from 'module-built-by-tshy'
 import { createRequire } from 'node:module'
-const req = createRequire(import.meta.url)
+const require = createRequire(import.meta.url)
 
 // create an object using the commonjs version
 function getObject() {


### PR DESCRIPTION
The variable holding the function returned by `createRequire()` is named `req` but the `require` function is being used below, so `require` is undefined here. This fixes that by ensuring that both variable names are the same.