### PR TITLE
WIP: Adding parallel build

### DIFF
--- a/src/build-esm.ts
+++ b/src/build-esm.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { relative, resolve } from 'node:path'
-import buildFail from './build-fail.js'
+import buildFail, { type BuildResult } from './build-fail.js'
 import config from './config.js'
 import * as console from './console.js'
 import ifExist from './if-exist.js'
@@ -13,34 +13,57 @@ import tsc from './which-tsc.js'
 const node = process.execPath
 const { esmDialects = [] } = config
 
-export const buildESM = () => {
+const isBuildResult = (x: any): x is BuildResult => {
+  return x && typeof x === 'object' && 'esmDialect' in x && 'code' in x
+}
+
+export const buildESM = async () => {
   setFolderDialect('src', 'esm')
-  for (const d of ['esm', ...esmDialects]) {
-    const pf = polyfills.get(d)
-    console.debug(chalk.cyan.dim('building ' + d))
-    const res = spawnSync(node, [tsc, '-p', `.tshy/${d}.json`], {
+
+  const buildPromises = esmDialects.map(esmDialect => new Promise<BuildResult>((resolve, reject) => {
+    const pf = polyfills.get(esmDialect);
+    console.debug(chalk.cyan.dim('building ' + esmDialect))
+    const child = spawn(node, [tsc, '-p', `.tshy/${esmDialect}.json`], {
       stdio: 'inherit',
     })
-    if (res.status || res.signal) {
-      setFolderDialect('src')
-      return buildFail(res)
+
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve({ esmDialect, code });
+      } else {
+        reject({ esmDialect, code, signal });
+      }
+    })
+  }))
+
+  try {
+    const results = await Promise.all(buildPromises); // Wait for all promises to resolve
+    results.forEach(({ esmDialect }) => {
+      const pf = polyfills.get(esmDialect)
+      setFolderDialect('.tshy-build/' + esmDialect, 'esm')
+      for (const [override, orig] of pf?.map.entries() ?? []) {
+        const stemFrom = resolve(
+          `.tshy-build/${esmDialect}`,
+          relative(resolve('src'), resolve(override)),
+        ).replace(/\.mts$/, '')
+        const stemTo = resolve(
+          `.tshy-build/${esmDialect}`,
+          relative(resolve('src'), resolve(orig)),
+        ).replace(/\.tsx?$/, '')
+        ifExist.unlink(`${stemTo}.js.map`)
+        ifExist.unlink(`${stemTo}.d.ts.map`)
+        ifExist.rename(`${stemFrom}.mjs`, `${stemTo}.js`)
+        ifExist.rename(`${stemFrom}.d.mts`, `${stemTo}.d.ts`)
+      }
+      console.error(chalk.cyan.bold('built ' + esmDialect))
+    });
+  } catch (error) {
+    setFolderDialect('src');
+    if (isBuildResult(error)) {
+      return buildFail(error)
     }
-    setFolderDialect('.tshy-build/' + d, 'esm')
-    for (const [override, orig] of pf?.map.entries() ?? []) {
-      const stemFrom = resolve(
-        `.tshy-build/${d}`,
-        relative(resolve('src'), resolve(override)),
-      ).replace(/\.mts$/, '')
-      const stemTo = resolve(
-        `.tshy-build/${d}`,
-        relative(resolve('src'), resolve(orig)),
-      ).replace(/\.tsx?$/, '')
-      ifExist.unlink(`${stemTo}.js.map`)
-      ifExist.unlink(`${stemTo}.d.ts.map`)
-      ifExist.rename(`${stemFrom}.mjs`, `${stemTo}.js`)
-      ifExist.rename(`${stemFrom}.d.mts`, `${stemTo}.d.ts`)
-    }
-    console.error(chalk.cyan.bold('built ' + d))
+    console.error(chalk.cyan.bold('failed to build'))
   }
+
   setFolderDialect('src')
 }

--- a/src/build-fail.ts
+++ b/src/build-fail.ts
@@ -7,7 +7,13 @@ import { unlink as unlinkImports } from './unbuilt-imports.js'
 import { unlink as unlinkSelfDep } from './self-link.js'
 import pkg from './package.js'
 
-export default (res: SpawnSyncReturns<Buffer>) => {
+export interface BuildResult {
+  esmDialect: string
+  code: number
+  signal?: NodeJS.Signals | null
+}
+
+export default (res: SpawnSyncReturns<Buffer> | BuildResult) => {
   setFolderDialect('src')
   unlinkImports(pkg, 'src')
   unlinkSelfDep(pkg, 'src')


### PR DESCRIPTION
Starting to create a parallel build, however, getting into some odd mocking issues such as the following:

```
2> test/build-esm.ts
node:internal/bootstrap/switches/does_own_process_state:144
    cachedCwd = rawMethods.cwd();
                           ^

Error: ENOENT: no such file or directory, uv_cwd
    at process.wrappedCwd [as cwd] (node:internal/bootstrap/switches/does_own_process_state:144:28)
    at
file:///Users/matthewp/git/tshy/node_modules/@tapjs/processinfo/dist/esm/canonical-source.js:7:21
    at ModuleJob.run (node:internal/modules/esm/module_job:262:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:475:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:104:9) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'uv_cwd'
}

Node.js v22.2.0
node:internal/bootstrap/switches/does_own_process_state:144
    cachedCwd = rawMethods.cwd();
                           ^

Error: ENOENT: no such file or directory, uv_cwd
    at process.wrappedCwd [as cwd] (node:internal/bootstrap/switches/does_own_process_state:144:28)
    at
file:///Users/matthewp/git/tshy/node_modules/@tapjs/processinfo/dist/esm/canonical-source.js:7:21
    at ModuleJob.run (node:internal/modules/esm/module_job:262:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:475:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:104:9) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'uv_cwd'
}
```