### PR TITLE
Fix tshy.project being a package

### DIFF
--- a/src/valid-project.ts
+++ b/src/valid-project.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'path'
 import { readFileSync } from 'node:fs'
 import fail from './fail.js'
 import { TshyConfig } from './types.js'
@@ -6,7 +5,7 @@ import { TshyConfig } from './types.js'
 export default (p: any): p is TshyConfig['project'] => {
   if (typeof p === 'string') {
     try {
-      readFileSync(resolve(p), 'utf8')
+      readFileSync(import.meta.resolve(p), 'utf8')
       return true
     } catch (_) {}
   }


### PR DESCRIPTION
In monorepo, I think it is fairly common for the base `tsconfig.json` file to be contained within an internal package.

It is for example [how turborepo documents](https://turbo.build/repo/docs/guides/tools/typescript#building-a-typescript-package) creating TS monorepos.

`import.meta.resolve` is a Release candidate. Let me know if you'd prefer like:

```ts
const require = createRequire(import.meta.url);
const pathName = require.resolve(p);
```