### PR TITLE
drop dead Node.js v18 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
         platform:
         - os: ubuntu-latest
           shell: bash


### PR DESCRIPTION
Support was dropped as of 3.0 in a05d3ba7b1e16f97ac20b01eb7888dbbaf39b5f4